### PR TITLE
Proper configurations for Windows and macOS

### DIFF
--- a/Bebop.sln
+++ b/Bebop.sln
@@ -5,42 +5,32 @@ VisualStudioVersion = 16.0.30615.102
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Core", "Core\Core.csproj", "{7AB412CB-1F1F-4449-9D51-A66E200F6248}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Compiler", "Compiler\Compiler.csproj", "{A509F5AB-5702-49EC-9B7F-09E8F24FC542}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Compiler", "Compiler\Compiler.csproj", "{A509F5AB-5702-49EC-9B7F-09E8F24FC542}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|x64 = Debug|x64
-		Release|x64 = Release|x64
-		Windows-Debug|x64 = Windows-Debug|x64
-		Windows-Release|x64 = Windows-Release|x64
 		macOS-Debug|x64 = macOS-Debug|x64
 		macOS-Release|x64 = macOS-Release|x64
+		Windows-Debug|x64 = Windows-Debug|x64
+		Windows-Release|x64 = Windows-Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{7AB412CB-1F1F-4449-9D51-A66E200F6248}.Debug|x64.ActiveCfg = Debug|x64
-		{7AB412CB-1F1F-4449-9D51-A66E200F6248}.Debug|x64.Build.0 = Debug|x64
-		{7AB412CB-1F1F-4449-9D51-A66E200F6248}.Release|x64.ActiveCfg = Release|x64
-		{7AB412CB-1F1F-4449-9D51-A66E200F6248}.Release|x64.Build.0 = Release|x64
-		{7AB412CB-1F1F-4449-9D51-A66E200F6248}.Windows-Debug|x64.ActiveCfg = Debug|x64
-		{7AB412CB-1F1F-4449-9D51-A66E200F6248}.Windows-Debug|x64.Build.0 = Debug|x64
-		{7AB412CB-1F1F-4449-9D51-A66E200F6248}.Windows-Release|x64.ActiveCfg = Release|x64
-		{7AB412CB-1F1F-4449-9D51-A66E200F6248}.Windows-Release|x64.Build.0 = Release|x64
 		{7AB412CB-1F1F-4449-9D51-A66E200F6248}.macOS-Debug|x64.ActiveCfg = Debug|x64
 		{7AB412CB-1F1F-4449-9D51-A66E200F6248}.macOS-Debug|x64.Build.0 = Debug|x64
 		{7AB412CB-1F1F-4449-9D51-A66E200F6248}.macOS-Release|x64.ActiveCfg = Release|x64
 		{7AB412CB-1F1F-4449-9D51-A66E200F6248}.macOS-Release|x64.Build.0 = Release|x64
-		{A509F5AB-5702-49EC-9B7F-09E8F24FC542}.Debug|x64.ActiveCfg = Windows-Debug|x64
-		{A509F5AB-5702-49EC-9B7F-09E8F24FC542}.Debug|x64.Build.0 = Windows-Debug|x64
-		{A509F5AB-5702-49EC-9B7F-09E8F24FC542}.Release|x64.ActiveCfg = Windows-Release|x64
-		{A509F5AB-5702-49EC-9B7F-09E8F24FC542}.Release|x64.Build.0 = Windows-Release|x64
-		{A509F5AB-5702-49EC-9B7F-09E8F24FC542}.Windows-Debug|x64.ActiveCfg = Windows-Debug|x64
-		{A509F5AB-5702-49EC-9B7F-09E8F24FC542}.Windows-Debug|x64.Build.0 = Windows-Debug|x64
-		{A509F5AB-5702-49EC-9B7F-09E8F24FC542}.Windows-Release|x64.ActiveCfg = Windows-Release|x64
-		{A509F5AB-5702-49EC-9B7F-09E8F24FC542}.Windows-Release|x64.Build.0 = Windows-Release|x64
+		{7AB412CB-1F1F-4449-9D51-A66E200F6248}.Windows-Debug|x64.ActiveCfg = Debug|x64
+		{7AB412CB-1F1F-4449-9D51-A66E200F6248}.Windows-Debug|x64.Build.0 = Debug|x64
+		{7AB412CB-1F1F-4449-9D51-A66E200F6248}.Windows-Release|x64.ActiveCfg = Release|x64
+		{7AB412CB-1F1F-4449-9D51-A66E200F6248}.Windows-Release|x64.Build.0 = Release|x64
 		{A509F5AB-5702-49EC-9B7F-09E8F24FC542}.macOS-Debug|x64.ActiveCfg = macOS-Debug|x64
 		{A509F5AB-5702-49EC-9B7F-09E8F24FC542}.macOS-Debug|x64.Build.0 = macOS-Debug|x64
 		{A509F5AB-5702-49EC-9B7F-09E8F24FC542}.macOS-Release|x64.ActiveCfg = macOS-Release|x64
 		{A509F5AB-5702-49EC-9B7F-09E8F24FC542}.macOS-Release|x64.Build.0 = macOS-Release|x64
+		{A509F5AB-5702-49EC-9B7F-09E8F24FC542}.Windows-Debug|x64.ActiveCfg = Windows-Debug|x64
+		{A509F5AB-5702-49EC-9B7F-09E8F24FC542}.Windows-Debug|x64.Build.0 = Windows-Debug|x64
+		{A509F5AB-5702-49EC-9B7F-09E8F24FC542}.Windows-Release|x64.ActiveCfg = Windows-Release|x64
+		{A509F5AB-5702-49EC-9B7F-09E8F24FC542}.Windows-Release|x64.Build.0 = Windows-Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Compiler/Compiler.csproj
+++ b/Compiler/Compiler.csproj
@@ -1,76 +1,72 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
-		<OutputType>Exe</OutputType>
-		<TargetFramework>net5.0</TargetFramework>
-		<Nullable>enable</Nullable>
-		<LangVersion>9.0</LangVersion>
-		<AssemblyName>bebopc</AssemblyName>
-		<Version>0.1.0</Version>
-		<Authors>Rainway, Inc.</Authors>
-		<PlatformTarget>x64</PlatformTarget>
-		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-		<AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
-		<OutputPath>../bin/compiler/$(Configuration)</OutputPath>
-		<NativeOutputPath>../bin/compiler/$(Configuration)/native/</NativeOutputPath>
-		<PublishDir>../bin/compiler/$(Configuration)/publish</PublishDir>
-		<Platforms>x64</Platforms>
-        <RuntimeIdentifiers>win-x64;osx-x64</RuntimeIdentifiers>
-		<Configurations>Windows-Debug;Windows-Release;macOS-Debug;macOS-Release</Configurations>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <LangVersion>9.0</LangVersion>
+    <AssemblyName>bebopc</AssemblyName>
+    <Version>0.1.0</Version>
+    <Authors>Rainway, Inc.</Authors>
+    <PlatformTarget>x64</PlatformTarget>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <OutputPath>../bin/compiler/$(Configuration)</OutputPath>
+    <NativeOutputPath>../bin/compiler/$(Configuration)/native/</NativeOutputPath>
+    <PublishDir>../bin/compiler/$(Configuration)/publish</PublishDir>
+    <Platforms>x64</Platforms>
+    <RuntimeIdentifiers>win-x64;osx-x64</RuntimeIdentifiers>
+    <Configurations>Windows-Debug;Windows-Release;macOS-Debug;macOS-Release</Configurations>
+  </PropertyGroup>
 
 
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Windows-Debug|x64' ">
+    <PlatformTarget>x64</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <Optimize>false</Optimize>
+    <DefineConstants>TRACE;DEBUG;NET;NET5_0;NETCOREAPP</DefineConstants>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+  </PropertyGroup>
 
-	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Windows-Debug|x64' ">
-	  <PlatformTarget>x64</PlatformTarget>
-	  <DebugSymbols>true</DebugSymbols>
-	  <Optimize>false</Optimize>
-	  <DefineConstants>TRACE;DEBUG;NET;NET5_0;NETCOREAPP</DefineConstants>
-        <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-	</PropertyGroup>
-    
-    
-	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Windows-Release|x64' ">
-	  <PublishSingleFile>true</PublishSingleFile>
-	  <PlatformTarget>x64</PlatformTarget>
-	  <Optimize>true</Optimize>
-	  <DefineConstants>TRACE;RELEASE;NET;NET5_0;NETCOREAPP</DefineConstants>
-        <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-         <IlcOptimizationPreference>Size</IlcOptimizationPreference>
-   
-	</PropertyGroup>
-    
-    
-	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'macOS-Debug|x64' ">
-	 <PlatformTarget>x64</PlatformTarget>
-        <DebugSymbols>true</DebugSymbols>
-      <Optimize>false</Optimize>
-      <DefineConstants>TRACE;DEBUG;NET;NET5_0;NETCOREAPP</DefineConstants>
-        <RuntimeIdentifier>osx-x64</RuntimeIdentifier>
-	</PropertyGroup>
-    
-    
-	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'macOS-Release|x64' ">
-	 <PlatformTarget>x64</PlatformTarget>
-     <PublishSingleFile>true</PublishSingleFile>
-     <Optimize>true</Optimize>
-      <DefineConstants>TRACE;RELEASE;NET;NET5_0;NETCOREAPP</DefineConstants>
-        <RuntimeIdentifier>osx-x64</RuntimeIdentifier>
-        <IlcOptimizationPreference>Size</IlcOptimizationPreference>
-	</PropertyGroup>
-    
-    
-    
-    
-	<ItemGroup>
-	  <ProjectReference Include="..\Core\Core.csproj" />
-	</ItemGroup>
 
-	<ItemGroup>
-	  <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="6.0.0-*" />
-	</ItemGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Windows-Release|x64' ">
+    <PublishSingleFile>true</PublishSingleFile>
+    <PlatformTarget>x64</PlatformTarget>
+    <Optimize>true</Optimize>
+    <DefineConstants>TRACE;RELEASE;NET;NET5_0;NETCOREAPP</DefineConstants>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <IlcOptimizationPreference>Size</IlcOptimizationPreference>
 
-	
+  </PropertyGroup>
+
+
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'macOS-Debug|x64' ">
+    <PlatformTarget>x64</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <Optimize>false</Optimize>
+    <DefineConstants>TRACE;DEBUG;NET;NET5_0;NETCOREAPP</DefineConstants>
+    <RuntimeIdentifier>osx-x64</RuntimeIdentifier>
+  </PropertyGroup>
+
+
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'macOS-Release|x64' ">
+    <PlatformTarget>x64</PlatformTarget>
+    <PublishSingleFile>true</PublishSingleFile>
+    <Optimize>true</Optimize>
+    <DefineConstants>TRACE;RELEASE;NET;NET5_0;NETCOREAPP</DefineConstants>
+    <RuntimeIdentifier>osx-x64</RuntimeIdentifier>
+    <IlcOptimizationPreference>Size</IlcOptimizationPreference>
+  </PropertyGroup>
+
+
+  <ItemGroup>
+    <ProjectReference Include="..\Core\Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="6.0.0-*" />
+  </ItemGroup>
+
 
 </Project>


### PR DESCRIPTION
You should be able to debug on macOS now. We will find out if .NET 5 supports macOS ARM64 (M1 chip) when yours arrives.