### PR TITLE
Nicer indentation for TypeScript codegen

### DIFF
--- a/Laboratory/Schemas/documentation.bop
+++ b/Laboratory/Schemas/documentation.bop
@@ -1,0 +1,41 @@
+enum DepE {
+    [deprecated("X in DepE")]
+    X = 1;
+}
+
+message DepM {
+    [deprecated("x in DepM")]
+    1 -> int32 x;
+}
+
+/* Documented enum */
+enum DocE {
+    /* Documented constant */
+    X = 1;
+
+    [deprecated("Y in DocE")]
+    Y = 2;
+
+    /* Deprecated, documented constant */
+    [deprecated("Z in DocE")]
+    Z = 3;
+}
+
+/* Documented message */
+message DocM {
+    /* Documented field */
+    1 -> int32 x;
+
+    [deprecated("y in DocM")]
+    2 -> int32 y;
+
+    /* Deprecated, documented field */
+    [deprecated("z in DocM")]
+    3 -> int32 z;
+}
+
+/* Documented struct */
+struct DocS {
+    /* Documented field */
+    int32 x;
+}


### PR DESCRIPTION
Before:
```ts
import { BebopView } from "bebop";

  export enum DepE {
     /**
      * @deprecated X in DepE
      */
      X = 1
  }
  export interface IDepM {
   /**
    * @deprecated x in DepM
    */
    x?: number
  }
```

After:

```ts
import { BebopView } from "bebop";

export enum DepE {
  /**
   * @deprecated X in DepE
   */
  X = 1,
}

export interface IDepM {
  /**
   * @deprecated x in DepM
   */
  x?: number;
}
```